### PR TITLE
headIdx Reformat

### DIFF
--- a/assets/data/enemies/avatar/susie-hacked.json
+++ b/assets/data/enemies/avatar/susie-hacked.json
@@ -51,7 +51,7 @@
     "healDropRate": 0,
     "boss": false,
     "bossOrder": 0,
-    "headIdx": 3,
+    "headIdx": "susie-hacked",
     "padding": {
         "x": 2,
         "y": 2

--- a/assets/data/enemies/avatar/susie.json
+++ b/assets/data/enemies/avatar/susie.json
@@ -51,7 +51,7 @@
     "healDropRate": 0,
     "boss": false,
     "bossOrder": 0,
-    "headIdx": 12,
+    "headIdx": "susie",
     "padding": {
         "x": 2,
         "y": 2

--- a/assets/data/players/headIdx.json.patch
+++ b/assets/data/players/headIdx.json.patch
@@ -5,12 +5,14 @@
 	"type": "ADD_ARRAY_ELEMENT",
 	"content": {
 		"id": "guildac.susie-hacked",
-		"img" : "media/gui/severed-heads/susie-hacked.png"
+		"img" : "media/gui/severed-heads/susie-hacked.png",
+		"name" : "susie-hacked"
 	}
 },{
 	"type": "ADD_ARRAY_ELEMENT",
 	"content": {
 		"id": "guildac.susie",
-		"img" : "media/gui/severed-heads/susie.png"
+		"img" : "media/gui/severed-heads/susie.png",
+		"name" : "susie"
 	}
 }]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "module": true,
     "ccmodDependencies": {
         "item-api": "^0.*",
-        "extendable-severed-heads": "^1.0.0",
+        "extendable-severed-heads": "^1.1.0",
         "modifier-api": "^0.1.0"
     },
     "scripts": {


### PR DESCRIPTION
Updated headIdx format for extendable-severed-heads 1.1.0, which allows this value to be defined as a string. This fixes conflicts with other mods.