### PR TITLE
vectorRestore only when necessary

### DIFF
--- a/assets/data/maps/guildac/arena/transport.json
+++ b/assets/data/maps/guildac/arena/transport.json
@@ -1221,7 +1221,7 @@
         "settings": {
             "name": "vectorRestore",
             "eventType": "PARALLEL",
-            "startCondition": "true",
+            "startCondition": "player.entity.name == 'Vector'",
             "endCondition": "false",
             "triggerType": "ONCE_PER_ENTRY",
             "mapId": 9251,

--- a/assets/data/maps/rhombus-sqr/interior/arena-01.json.patch
+++ b/assets/data/maps/rhombus-sqr/interior/arena-01.json.patch
@@ -10,8 +10,8 @@
         "level": 0,
         "settings": {
             "name": "vectorRestore",
-            "eventType": "PARALLEL",
-            "startCondition": "true",
+            "eventType": "INTERRUPTABLE",
+            "startCondition": "player.entity.name == 'Vector'",
             "endCondition": "false",
             "triggerType": "ONCE_PER_ENTRY",
             "mapId": 2251,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "ccmodDependencies": {
         "item-api": "^0.*",
         "extendable-severed-heads": "^1.1.0",
-        "modifier-api": "^0.1.0"
+        "modifier-api": "^0.1.0",
+	"cc-alybox": ">=1.0.0"
     },
     "scripts": {
         "format": "npm run minify-json && npm run json-beautify && npm run js-beautify",


### PR DESCRIPTION
The **vectorRestore** EventTrigger in the arena lobby is disruptive to other mods that allow you to play as other characters, so with this fix it will only trigger if **player.entity.name == 'Vector'**.

There was also a **vectorRestore** EventTrigger in **\ArcaneLab-dev\assets\data\maps\guildac\arena\transport.json**, so I changed the condition for that one too. This allows playing the arena map as a non-Lea character without swapping to Lea.

The variable **player.entity.name**  is used to determine the player's current character config. This is implemented in AlyBox, a small library mod: AlyBox: https://github.com/lexisother/cc-alybox

This PR adds AlyBox as a dependency so it can use this feature.

The other thing I changed is to convert the **vectorRestore** EventTrigger in the arena lobby from PARALLEL to INTERRUPTABLE. With PARALLEL events, they disable quick travel and prevent the player from leaving the map via TeleportGround while the event is running. This was disruptive so I changed it to INTERRUPTABLE.

I have tested this by walking into the arena as the Vector player config as well as any other player config and confirmed that it only triggers for the Vector.