### PR TITLE
Add ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -1,0 +1,15 @@
+{
+  "id": "arcane-lab",
+  "version": "0.1.1",
+  "title": "\\c[3]Arcane Lab\\c[0]",
+  "description": ":)",
+  "repository": "https://github.com/2hh8899/ArcaneLab",
+  "tags": ["character", "maps", "boss", "puzzle"],
+  "authors": ["eisus", "ac2pic", "WatDuhHekBro"],
+  "dependencies": {
+    "ccloader": "^2.14.1",
+    "extendable-severed-heads": "^1.0.0"
+  },
+  "prestart": "prestart.js"
+}
+

--- a/ccmod.json
+++ b/ccmod.json
@@ -4,7 +4,7 @@
   "title": "\\c[3]Arcane Lab\\c[0]",
   "description": ":)",
   "repository": "https://github.com/2hh8899/ArcaneLab",
-  "tags": ["character", "maps", "boss", "puzzle"],
+  "tags": ["player character", "party member", "maps", "quests", "boss", "puzzle"],
   "authors": ["eisus", "ac2pic", "WatDuhHekBro"],
   "dependencies": {
     "ccloader": "^2.14.1",


### PR DESCRIPTION
Hi!
I want to add your mod to a centralized mod repository called CCModDB.
It will allow the upcoming in-game [mod manager](https://github.com/CCDirectLink/CCModManager) to see your mod and make it one-click-installable with all the dependencies. (it's not CCUpdaterUI)
It requires `ccmod.json` to be present.
Please create a new release or update the release `.ccmod` after merging.

You can see the full mod tag list [here](https://github.com/krypciak/CCModDB/blob/ccmodjson/CCMOD-STANDARD.md)
You can change the mod tags as you please, I'm not sure I got everything right